### PR TITLE
Add famous-cli-alike auto-update functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function( grunt ) {
         src: 'Gruntfile.js'
       },
       lib: {
-        src: [ 'bin/**/*.js', 'commands/**/*.js', 'server/**/*.js' ]
+        src: [ 'bin/**/*.js', 'commands/**/*.js', 'lib/**/*.js', 'server/**/*.js' ]
       }
     },
 

--- a/bin/p5-cli.js
+++ b/bin/p5-cli.js
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
+// Auto-update the CLI if the installed version is behind the latest
+var autoUpdate = require( '../lib/auto-update' );
+
 // Use commander to define CLI commands
 var program = require( 'commander' );
 
-// Get version from package.json
-var appVersion = require( '../package' ).version;
-
 // Link to the definition of the "serve" CLI subcommand
 var serveCommand = require( '../commands/serve' );
+
+// Get version from package.json
+var appVersion = require( '../package' ).version;
 
 // Create the CLI application object
 var p5cli = program.version( appVersion );
@@ -45,5 +48,8 @@ p5cli.command( 'serve' )
   // Run the "serve" command with the provided CLI options
   .action( serveCommand );
 
-// Kick off command parsing & execution
-p5cli.parse( process.argv );
+// Ensure latest CLI version
+autoUpdate().then(function() {
+  // Kick off command parsing & execution
+  p5cli.parse( process.argv );
+});

--- a/lib/auto-update.js
+++ b/lib/auto-update.js
@@ -1,0 +1,81 @@
+// Adapted from famous-cli https://github.com/Famous/famous-cli/blob/master/lib/autoupdate.js
+'use strict';
+
+// Utility for colorizing terminal output
+var chalk = require( 'chalk' );
+
+// Cross-platform utility to invoke command-line processes
+var spawn = require( 'win-spawn' );
+
+// Tools for retrieving and validating NPM package release versions
+var semver = require( 'semver' );
+var latestVersion = require( 'latest-version' );
+
+// Details about the installed p5-cli package
+var current = require( '../package' ).version;
+
+/**
+ * update
+ *
+ * Run the update command
+ * @private
+ * @param {function} callback function to execute with the return code from the update command
+ * @returns {Promise} A promise that will complete when the update does
+ */
+function update( callback ) {
+  return new Promise(function( resolve, reject ) {
+    var child = spawn( 'npm', [ 'install', '-g', 'p5-cli' ]);
+
+    child.on( 'close', function( statusCode ) {
+      if ( statusCode === 0 ) {
+        console.log( 'Update successful!' );
+        resolve();
+      } else {
+        console.log([
+          '\n', chalk.red( 'Update failed.' ),
+          'It is possible you may need to run "npm install -g p5-cli" with\n',
+          '"sudo" (OSX) or "run as administrator" (Windows).\n',
+          'Continuing with the currently-installed version of p5...'
+        ].join( ' ' ));
+        reject( statusCode );
+      }
+    });
+  });
+}
+
+/**
+ * autoUpdate
+ *
+ * Check whether the currently installed version of p5-cli is behind the latest
+ * version published in npm: auto-update if an update is required.
+ *
+ * @returns {Promise} A promise that will complete when the version has been verified
+ * to be the latest or when the version update completes
+ */
+function autoUpdate() {
+  return new Promise(function( resolve, reject ) {
+
+    // Get the latest version of p5-cli
+    latestVersion( 'p5-cli', function( err, latest ) {
+      if ( err ) {
+        reject( err );
+      }
+
+      if ( semver.lt( current, latest ) ) {
+        // Notify user that p5 is being updated
+        console.log([
+          chalk.bold( 'p5-cli' ),
+          'version',
+          current,
+          'is out of date. Updating to',
+          latest + '...'
+        ].join( ' ' ));
+
+        resolve( update() );
+      }
+      resolve();
+    });
+  });
+}
+
+module.exports = autoUpdate;

--- a/package.json
+++ b/package.json
@@ -22,20 +22,24 @@
     "p5": "bin/p5-cli.js"
   },
   "dependencies": {
+    "chalk": "^1.1.1",
     "combynexpress": "^1.0.0",
     "commander": "^2.8.1",
-    "express": "^4.12.4",
-    "p5": "^0.4.5",
-    "serve-favicon": "^2.2.1",
-    "serve-index": "^1.6.4"
+    "express": "^4.13.3",
+    "latest-version": "^1.0.1",
+    "p5": "^0.4.8",
+    "semver": "^5.0.1",
+    "serve-favicon": "^2.3.0",
+    "serve-index": "^1.7.2",
+    "win-spawn": "^2.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.2",
-    "grunt-jscs": "^1.8.0",
+    "grunt-jscs": "^2.1.0",
     "jscs-stylish": "^0.3.1",
-    "jshint-stylish": "^2.0.0",
+    "jshint-stylish": "^2.0.1",
     "load-grunt-tasks": "^3.2.0"
   }
 }


### PR DESCRIPTION
This commit causes P5-CLI to check its own installed version when you run any CLI command; it self-updates the globally-installed p5-cli package if it finds itself to be out of date.
